### PR TITLE
Introduces paginated get_last_transactions_by_address api endpoint

### DIFF
--- a/apps/neoscan/lib/neoscan/api/api.ex
+++ b/apps/neoscan/lib/neoscan/api/api.ex
@@ -14,6 +14,7 @@ defmodule Neoscan.Api do
   alias Neoscan.Transactions.Transaction
   alias Neoscan.ChainAssets
   alias Neoscan.ChainAssets.Asset
+  alias Neoscan.BalanceHistories
   alias Neoscan.Blocks.Block
   alias Neoscan.Blocks
   alias Neoscan.Vouts
@@ -1041,6 +1042,71 @@ defmodule Neoscan.Api do
       |> Map.put(:vouts, new_vouts)
       |> Map.put(:vin, new_vins)
     end)
+  end
+
+  @doc """
+  Returns the last 15 transaction models in the chain for the selected address
+  from its hash_string, paginated.
+
+  ## Examples
+
+      /api/main_net/v1/get_last_transactions_by_address/{hash_string}/{page}
+      [{
+          "vouts": [
+            {
+              "value": float,
+              "n": integer,
+              "asset": "name_string",
+              "address": "hash_string"
+            },
+            ...
+          ],
+          "vin": [
+            {
+              "value": float,
+              "txid": "tx_id_string",
+              "n": integer,
+              "asset": "name_string",
+              "address_hash": "hash_string"
+            },
+            ...
+          ],
+          "version": integer,
+          "type": "type_string",
+          "txid": "tx_id_string",
+          "time": unix_time,
+          "sys_fee": "string",
+          "size": integer,
+          "scripts": [
+            {
+              "verification": "hash_string",
+              "invocation": "hash_string"
+            }
+          ],
+          "pubkey": hash_string,
+          "nonce": integer,
+          "net_fee": "string",
+          "description": string,
+          "contract": array,
+          "claims": array,
+          "block_height": integer,
+          "block_hash": "hash_string",
+          "attributes": array,
+          "asset": array
+        },
+        ...
+      ]
+
+  """
+  def get_last_transactions_by_address(hash_string, page) do
+
+    transactions =
+      BalanceHistories.paginate_history_transactions(
+        hash_string,
+        page || 1
+      )
+
+    transactions
   end
 
   @doc """

--- a/apps/neoscan_web/assets/static/doc/Neoscan.Api.html
+++ b/apps/neoscan_web/assets/static/doc/Neoscan.Api.html
@@ -215,6 +215,16 @@ If no <code class="inline">type</code> is provided, returns all types</p>
 </div>
 <div class="summary-row">
   <div class="summary-signature">
+    <a href="#get_last_transactions_by_address/1">get_last_transactions_by_address(hash_string, page)</a>
+  </div>
+
+    <div class="summary-synopsis"><p>Returns the last 15 transaction models in the chain for the selected address from its <code class="inline">hash_string</code>. 
+If no <code class="inline">page</code> is provided, returns page 1 (latest transactions).</p>
+</div>
+
+</div>
+<div class="summary-row">
+  <div class="summary-signature">
     <a href="#get_nodes/0">get_nodes()</a>
   </div>
 
@@ -790,6 +800,77 @@ If no <code class="inline">type</code> is provided, returns all types</p>
 
 <pre><code class="elixir">/api/main_net/v1/get_last_transactions/{type}
 /api/main_net/v1/get_last_transactions
+[{
+    &quot;vouts&quot;: [
+      {
+        &quot;value&quot;: float,
+        &quot;n&quot;: integer,
+        &quot;asset&quot;: &quot;name_string&quot;,
+        &quot;address&quot;: &quot;hash_string&quot;
+      },
+      ...
+    ],
+    &quot;vin&quot;: [
+      {
+        &quot;value&quot;: float,
+        &quot;txid&quot;: &quot;tx_id_string&quot;,
+        &quot;n&quot;: integer,
+        &quot;asset&quot;: &quot;name_string&quot;,
+        &quot;address_hash&quot;: &quot;hash_string&quot;
+      },
+      ...
+    ],
+    &quot;version&quot;: integer,
+    &quot;type&quot;: &quot;type_string&quot;,
+    &quot;txid&quot;: &quot;tx_id_string&quot;,
+    &quot;time&quot;: unix_time,
+    &quot;sys_fee&quot;: &quot;string&quot;,
+    &quot;size&quot;: integer,
+    &quot;scripts&quot;: [
+      {
+        &quot;verification&quot;: &quot;hash_string&quot;,
+        &quot;invocation&quot;: &quot;hash_string&quot;
+      }
+    ],
+    &quot;pubkey&quot;: hash_string,
+    &quot;nonce&quot;: integer,
+    &quot;net_fee&quot;: &quot;string&quot;,
+    &quot;description&quot;: string,
+    &quot;contract&quot;: array,
+    &quot;claims&quot;: array,
+    &quot;block_height&quot;: integer,
+    &quot;block_hash&quot;: &quot;hash_string&quot;,
+    &quot;attributes&quot;: array,
+    &quot;asset&quot;: array
+  },
+  ...
+]</code></pre>
+
+  </section>
+</div>
+<div class="detail" id="get_last_transactions_by_address/1">
+
+
+  <div class="detail-header">
+    <a href="#get_last_transactions_by_address/1" class="detail-link" title="Link to this function">
+      <span class="icon-link" aria-hidden="true"></span>
+      <span class="sr-only">Link to this function</span>
+    </a>
+    <span class="signature">get_last_transactions_by_address(hash_string, page)</span>
+
+
+
+  </div>
+  <section class="docstring">
+    <p>Returns the last 15 transaction models in the chain for the selected address from its <code class="inline">hash_string</code>.
+If no <code class="inline">page</code> is provided, returns page 1 (latest transactions)</p>
+<h2 id="get_last_transactions_by_address/1-examples" class="section-heading">
+  <a href="#get_last_transactions_by_address/1-examples" class="hover-link"><span class="icon-link" aria-hidden="true"></span></a>
+  Examples
+</h2>
+
+<pre><code class="elixir">/api/main_net/v1/get_last_transactions_by_address/{hash_string}/{page}
+/api/main_net/v1/get_last_transactions_by_address/{hash_string}
 [{
     &quot;vouts&quot;: [
       {

--- a/apps/neoscan_web/lib/neoscan_web/controllers/api_controller.ex
+++ b/apps/neoscan_web/lib/neoscan_web/controllers/api_controller.ex
@@ -73,6 +73,16 @@ defmodule NeoscanWeb.ApiController do
     json(conn, transactions)
   end
 
+  def get_last_transactions_by_address(conn, %{"hash" => hash}) do
+    transactions = Api.get_last_transactions_by_address(hash, 1)
+    json(conn, transactions)
+  end
+
+  def get_last_transactions_by_address(conn, %{"hash" => hash, "page" => page}) do
+    transactions = Api.get_last_transactions_by_address(hash, page)
+    json(conn, transactions)
+  end
+
   def get_all_nodes(conn, %{}) do
     nodes = Api.get_all_nodes()
     json(conn, nodes)

--- a/apps/neoscan_web/lib/neoscan_web/router.ex
+++ b/apps/neoscan_web/lib/neoscan_web/router.ex
@@ -61,6 +61,8 @@ defmodule NeoscanWeb.Router do
     get("/get_highest_block", ApiController, :get_highest_block)
     get("/get_last_transactions", ApiController, :get_last_transactions)
     get("/get_last_transactions/:type", ApiController, :get_last_transactions)
+    get("/get_last_transactions_by_address/:hash", ApiController, :get_last_transactions_by_address)
+    get("/get_last_transactions_by_address/:hash/:page", ApiController, :get_last_transactions_by_address)
     get("/get_transaction/:hash", ApiController, :get_transaction)
     get("/get_all_nodes", ApiController, :get_all_nodes)
     get("/get_height", ApiController, :get_height)


### PR DESCRIPTION
This is needed for the neon wallet redesign's transaction history screen, which will be moving off of neon-wallet-db as it requires otherwise unavailable metadata such as `time` and nep5 token information.