### PR TITLE
Improve unit test 3

### DIFF
--- a/apps/neoscan/lib/neoscan/blocks/blocks.ex
+++ b/apps/neoscan/lib/neoscan/blocks/blocks.ex
@@ -313,19 +313,6 @@ defmodule Neoscan.Blocks do
   end
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for tracking block changes.
-
-  ## Examples
-
-      iex> change_block(block)
-      %Ecto.Changeset{source: %Block{}}
-
-  """
-  def change_block(%Block{} = block) do
-    Block.changeset(block, %{})
-  end
-
-  @doc """
   Returns the heighest block in the database
 
   ## Examples
@@ -386,7 +373,7 @@ defmodule Neoscan.Blocks do
 
   """
   def delete_blocks([block | tail]), do: [delete_block(block) | delete_blocks(tail)]
-  def delete_blocks([]), do: {:ok, "Deleted"}
+  def delete_blocks([]), do: []
 
   @doc """
   delete all blocks heigher than `height`

--- a/apps/neoscan/lib/neoscan/chain_assets/assets.ex
+++ b/apps/neoscan/lib/neoscan/chain_assets/assets.ex
@@ -59,16 +59,8 @@ defmodule Neoscan.ChainAssets do
       get_token_by_contract(String.slice(to_string(token["script_hash"]), -40..-1)) == nil
     end)
     |> Enum.each(fn token -> add_token(token) end)
-    |> check_tokens_creation(tokens)
-  end
 
-  def check_tokens_creation(:ok, tokens) do
     tokens
-  end
-
-  def check_tokens_creation(_) do
-    Logger.info("Error creating token")
-    raise "Error creating token"
   end
 
   @doc """
@@ -102,7 +94,7 @@ defmodule Neoscan.ChainAssets do
       "not found"
 
   """
-  def get_token_by_contract(hash) do
+  defp get_token_by_contract(hash) do
     query = from(e in Asset, where: e.contract == ^hash)
 
     Repo.all(query)
@@ -122,31 +114,16 @@ defmodule Neoscan.ChainAssets do
 
   """
   def get_asset_name_by_hash(hash) do
-    cond do
-      String.length(hash) > 40 ->
-        query =
-          from(
-            e in Asset,
-            where: e.txid == ^hash,
-            select: e.name
-          )
+    query =
+      if String.length(hash) > 40 do
+        from(e in Asset, where: e.txid == ^hash, select: e.name)
+      else
+        from(e in Asset, where: e.contract == ^hash, select: e.name)
+      end
 
-        Repo.all(query)
-        |> List.first()
-        |> filter_name
-
-      true ->
-        query =
-          from(
-            e in Asset,
-            where: e.contract == ^hash,
-            select: e.name
-          )
-
-        Repo.all(query)
-        |> List.first()
-        |> filter_name
-    end
+    Repo.all(query)
+    |> List.first()
+    |> filter_name
   end
 
   @doc """
@@ -163,43 +140,28 @@ defmodule Neoscan.ChainAssets do
   """
   def get_asset_precision_by_hash(hash) do
     query =
-      cond do
-        String.length(hash) == 40 ->
-          from(
-            e in Asset,
-            where: e.contract == ^hash,
-            select: e.precision
-          )
-
-        true ->
-          from(
-            e in Asset,
-            where: e.txid == ^hash,
-            select: e.precision
-          )
+      if String.length(hash) == 40 do
+        from(e in Asset, where: e.contract == ^hash, select: e.precision)
+      else
+        from(e in Asset, where: e.txid == ^hash, select: e.precision)
       end
 
     Repo.all(query)
     |> List.first()
   end
 
-  def filter_name(nil) do
-    "Asset not Found"
-  end
+  def filter_name(nil), do: "Asset not Found"
 
   def filter_name(asset) do
     case Enum.find(asset, fn %{"lang" => lang} -> lang == "en" end) do
+      %{"name" => "AntShare"} ->
+        "NEO"
+
+      %{"name" => "AntCoin"} ->
+        "GAS"
+
       %{"name" => name} ->
-        cond do
-          name == "AntShare" ->
-            "NEO"
-
-          name == "AntCoin" ->
-            "GAS"
-
-          true ->
-            name
-        end
+        name
 
       nil ->
         %{"name" => name} = Enum.at(asset, 0)
@@ -280,9 +242,7 @@ defmodule Neoscan.ChainAssets do
     create_asset(txid, new_asset)
   end
 
-  def create(nil, _txid, _time) do
-    nil
-  end
+  def create(nil, _txid, _time), do: nil
 
   @doc """
   Issue assets
@@ -294,9 +254,7 @@ defmodule Neoscan.ChainAssets do
     end)
   end
 
-  def issue(_type, _vouts) do
-    nil
-  end
+  def issue(_type, _vouts), do: nil
 
   def verify_asset(hash, time) do
     case Api.check_asset(hash) do

--- a/apps/neoscan/lib/neoscan/chain_assets/assets.ex
+++ b/apps/neoscan/lib/neoscan/chain_assets/assets.ex
@@ -94,7 +94,7 @@ defmodule Neoscan.ChainAssets do
       "not found"
 
   """
-  defp get_token_by_contract(hash) do
+  def get_token_by_contract(hash) do
     query = from(e in Asset, where: e.contract == ^hash)
 
     Repo.all(query)

--- a/apps/neoscan/lib/neoscan/helpers/helpers.ex
+++ b/apps/neoscan/lib/neoscan/helpers/helpers.ex
@@ -129,25 +129,14 @@ defmodule Neoscan.Helpers do
     end
   end
 
-  def contract?(hash) do
-    cond do
-      String.length(hash) == 64 ->
-        false
-
-      true ->
-        true
-    end
-  end
+  def contract?(hash), do: String.length(hash) != 64
 
   def apply_precision(integer, hash, precision) do
-    cond do
-      String.length(hash) == 40 ->
-        num = integer / :math.pow(10, precision)
-
-        "#{num}"
-
-      true ->
-        "#{integer}"
+    if String.length(hash) == 40 do
+      num = integer / :math.pow(10, precision)
+      "#{num}"
+    else
+      "#{integer}"
     end
   end
 end

--- a/apps/neoscan/mix.exs
+++ b/apps/neoscan/mix.exs
@@ -49,6 +49,7 @@ defmodule Neoscan.Mixfile do
       {:ecto, "~> 2.1"},
       {:ex_machina, "~> 2.0", only: [:test, :travis]},
       {:excoveralls, "~> 0.8", only: [:test, :travis]},
+      {:mock, "~> 0.3.0", only: [:test, :travis]},
       {:poison, "~> 3.1"},
       {:scrivener_ecto, "~> 1.0"}
     ]

--- a/apps/neoscan/test/balance_histories/balance_histories_test.exs
+++ b/apps/neoscan/test/balance_histories/balance_histories_test.exs
@@ -3,6 +3,7 @@ defmodule Neoscan.BalanceHistories.BalanceHistoriesTest do
 
   alias Neoscan.BalanceHistories
   alias Neoscan.BalanceHistories.History
+  import Neoscan.Factory
 
   test "change_history/3" do
     valid_attrs = %{
@@ -12,5 +13,48 @@ defmodule Neoscan.BalanceHistories.BalanceHistoriesTest do
     }
 
     BalanceHistories.change_history(%History{}, %{id: 124, address: "dsfj"}, valid_attrs)
+  end
+
+  test "add_tx_id/4" do
+    attrs = %{
+      txid: "1234",
+      balance: 1235,
+      block_height: 0,
+      time: 1234,
+      tx_ids: nil
+    }
+
+    assert %{
+             balance: 1235,
+             block_height: 0,
+             time: 1234,
+             tx_ids: %{
+               balance: 1235,
+               block_height: 45,
+               time: 123,
+               txid: "2345"
+             },
+             txid: "1234"
+           } == BalanceHistories.add_tx_id(attrs, "2345", 45, 123)
+  end
+
+  test "count_hist_for_address/1" do
+    history = insert(:history)
+    assert 1 == BalanceHistories.count_hist_for_address(history.address_hash)
+  end
+
+  test "get_graph_data_for_address/1" do
+    history =
+      insert(:history, %{
+        balance: %{
+          "assethash" => %{
+            "amount" => 456,
+            "time" => 123
+          }
+        }
+      })
+
+    assert [%{assets: [%{"Asset not Found" => 456}], time: 123}] ==
+             BalanceHistories.get_graph_data_for_address(history.address_hash)
   end
 end

--- a/apps/neoscan/test/chain_assets/asset_test.exs
+++ b/apps/neoscan/test/chain_assets/asset_test.exs
@@ -1,0 +1,67 @@
+defmodule Neoscan.ChainAssets.AssetTest do
+  use Neoscan.DataCase
+  alias Neoscan.ChainAssets.Asset
+
+  describe "schema" do
+    test "empty schema" do
+      asset = %Asset{}
+      assert is_nil(asset.txid)
+    end
+  end
+
+  describe "changeset/2" do
+    test "returns invalid changeset when attrs are missing" do
+      missing_params = %{}
+
+      changeset = Asset.changeset(%Asset{}, missing_params)
+      refute changeset.valid?
+      assert %{txid: ["is invalid"]} = errors_on(changeset)
+      assert %{admin: ["can't be blank"]} = errors_on(changeset)
+      assert %{amount: ["can't be blank"]} = errors_on(changeset)
+      assert %{name: ["can't be blank"]} = errors_on(changeset)
+      assert %{owner: ["can't be blank"]} = errors_on(changeset)
+      assert %{precision: ["can't be blank"]} = errors_on(changeset)
+      assert %{type: ["can't be blank"]} = errors_on(changeset)
+      assert %{time: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "returns invalid changeset when attrs are invalid" do
+      cast_fields = [:admin, :amount, :owner, :precision, :type, :time]
+
+      invalid_attrs =
+        cast_fields
+        |> Enum.map(fn field -> {Atom.to_string(field), :invalid} end)
+        |> Map.new()
+
+      changeset = Asset.changeset("1234", invalid_attrs)
+      refute changeset.valid?
+      errors = errors_on(changeset)
+
+      Enum.each(cast_fields, fn field ->
+        assert Map.get(errors, field) == ["is invalid"]
+      end)
+    end
+
+    test "returns valid changeset when attrs are valid" do
+      valid_attrs = %{
+        "admin" => "abc",
+        "amount" => 123.12,
+        "owner" => "def",
+        "precision" => 12,
+        "type" => "abc",
+        "time" => 1432,
+        "txid" => "234",
+        "name" => [%{"abc" => "def"}]
+      }
+
+      changeset = Asset.changeset("125", valid_attrs)
+
+      assert changeset.valid?
+    end
+  end
+
+  test "update_changeset/2" do
+    assert Asset.update_changeset(%Asset{}, %{issued: 123.3232}).valid?
+    refute Asset.update_changeset(%Asset{}, %{issued: "hello"}).valid?
+  end
+end

--- a/apps/neoscan/test/chain_assets/assets_test.exs
+++ b/apps/neoscan/test/chain_assets/assets_test.exs
@@ -1,0 +1,183 @@
+defmodule Neoscan.ChainAssets.AssetsTest do
+  use Neoscan.DataCase
+  alias Neoscan.ChainAssets
+  alias Neoscan.ChainAssets.Asset
+  import Neoscan.Factory
+  import Mock
+  import ExUnit.CaptureLog
+
+  test "create_asset/2" do
+    assert %Asset{} =
+             ChainAssets.create_asset("1394202", %{
+               "admin" => "abc",
+               "amount" => 123.12,
+               "owner" => "def",
+               "precision" => 12,
+               "type" => "abc",
+               "time" => 1432,
+               "name" => [%{"abc" => "def"}]
+             })
+  end
+
+  test "add_token/1" do
+    with_mock Neoscan.Blocks, get_block_time: fn _ -> 1234 end do
+      response = %{
+        "token" => %{
+          "name" => "n\u0000am\u0000e",
+          "contract_address" => "23243",
+          "decimals" => 12,
+          "script_hash" => "d9j21092901j90j2190dj219dj29jd290ffijunvcuzncz9212903nf0932n9203n"
+        },
+        "tx" =>
+          "d9j21092901j90j2190dj219dj29jd290ffijunvcuzncz9212903nf0932n9203ncxkmakasfkasfskjfa"
+      }
+
+      asset = ChainAssets.add_token(response)
+      assert [%{"lang" => "en", "name" => "name"}] == asset.name
+      assert 1234 == asset.time
+      assert "23243" == asset.admin
+      assert 12 == asset.precision
+      assert "j29jd290ffijunvcuzncz9212903nf0932n9203n" == asset.contract
+      assert "dj219dj29jd290ffijunvcuzncz9212903nf0932n9203ncxkmakasfkasfskjfa" == asset.txid
+    end
+  end
+
+  test "create_tokens/1" do
+    with_mock Neoscan.Blocks, get_block_time: fn _ -> 1234 end do
+      insert(:asset, %{txid: "contracthash"})
+
+      response = %{
+        "token" => %{
+          "name" => "n\u0000am\u0000e",
+          "contract_address" => "23243",
+          "decimals" => 12,
+          "script_hash" => "contracthash"
+        },
+        "tx" =>
+          "d9j21092901j90j2190dj219dj29jd290ffijunvcuzncz9212903nf0932n9203ncxkmakasfkasfskjfa"
+      }
+
+      assert [response] == ChainAssets.create_tokens([response])
+    end
+  end
+
+  test "get_asset_by_hash/1" do
+    asset = insert(:asset)
+    asset1 = ChainAssets.get_asset_by_hash(asset.txid)
+    assert asset1.txid == asset.txid
+  end
+
+  test "get_asset_name_by_hash/1" do
+    asset =
+      insert(:asset, %{contract: "helloworld", name: [%{"name" => "AntShare", "lang" => "en"}]})
+
+    assert "NEO" == ChainAssets.get_asset_name_by_hash(asset.contract)
+
+    asset =
+      insert(:asset, %{contract: "helloworld2", name: [%{"name" => "AntCoin", "lang" => "en"}]})
+
+    assert "GAS" == ChainAssets.get_asset_name_by_hash(asset.contract)
+
+    asset =
+      insert(:asset, %{contract: "helloworld3", name: [%{"name" => "RandomName", "lang" => "en"}]})
+
+    assert "RandomName" == ChainAssets.get_asset_name_by_hash(asset.contract)
+    asset = insert(:asset, %{contract: "helloworld4", name: [%{"name" => "你好", "lang" => "cn"}]})
+    assert "你好" == ChainAssets.get_asset_name_by_hash(asset.contract)
+
+    assert "Asset not Found" == ChainAssets.get_asset_name_by_hash("notexisting thing")
+
+    txid = "superlongtxidsuperlongtxidsuperlongtxid12"
+    asset = insert(:asset, %{txid: txid, name: [%{"name" => "AntShare", "lang" => "en"}]})
+    assert "NEO" == ChainAssets.get_asset_name_by_hash(asset.txid)
+  end
+
+  test "get_asset_precision_by_hash/1" do
+    contract = "superlongtxidsuperlongtxidsuperlongtxid1"
+    asset = insert(:asset, %{contract: contract, precision: 123})
+    assert 123 == ChainAssets.get_asset_precision_by_hash(asset.contract)
+
+    asset = insert(:asset, %{txid: "1235", precision: 123})
+    assert 123 == ChainAssets.get_asset_precision_by_hash(asset.txid)
+  end
+
+  test "list_assets/0" do
+    assert is_list(ChainAssets.list_assets())
+  end
+
+  test "update_asset/2" do
+    asset = insert(:asset)
+    asset = ChainAssets.update_asset(asset, %{issued: 1023.12})
+    assert 1023.12 == asset.issued
+  end
+
+  test "add_issued_value/2" do
+    asset = insert(:asset)
+
+    assert capture_log(fn ->
+             assert {:error, "Non existant asset cant be issued!"} ==
+                      ChainAssets.add_issued_value("notexisting", 123.3)
+           end) =~ "Error issuing asset"
+
+    assert 123.4 == ChainAssets.add_issued_value(asset.txid, 123.4).issued
+  end
+
+  test "create/3" do
+    asset = %{
+      "amount" => "123.4",
+      "admin" => "string",
+      "owner" => "string",
+      "name" => [%{"lang" => "en", "name" => "AntShare"}],
+      "precision" => 12,
+      "type" => "type"
+    }
+
+    asset = ChainAssets.create(asset, "1234", 1234)
+    assert 123.4 == asset.amount
+    assert 1234 == asset.time
+    assert is_nil(ChainAssets.create(nil, "1234", 1234))
+  end
+
+  test "issue/2" do
+    assert is_nil(ChainAssets.issue("random", []))
+
+    asset1 =
+      insert(:asset, %{txid: "2323322942389383289433432433244234232343443342423344324324323444"})
+
+    asset2 =
+      insert(:asset, %{txid: "2323322942389383289433432433244234232343443342423344324324323445"})
+
+    vouts = [
+      %{"asset" => asset1.txid, "value" => "123.4"},
+      %{"asset" => asset2.txid, "value" => "567.8"}
+    ]
+
+    ChainAssets.issue("IssueTransaction", vouts)
+    assert 123.4 == ChainAssets.get_asset_by_hash(asset1.txid).issued
+    assert 567.8 == ChainAssets.get_asset_by_hash(asset2.txid).issued
+  end
+
+  #  test "verify_asset/2" do
+  #    asset = insert(:asset)
+  #    ChainAssets.verify_asset(asset.txid, asset.time)
+  #  end
+
+  #  test "check_db/2" do
+  #    with_mocks(
+  #      [
+  #        {NeoscanSync.HttpCalls, [], [url: fn _ -> 1234 end]},
+  #        {NeoscanSync.Blockchain, [], [get_asset: fn _, _ -> "helloworld" end]},
+  #        {NeoscanSync.Notifications, [], [get_token_notifications: fn -> [] end]}
+  #      ]
+  #    ) do
+  #      asset = insert(:asset)
+  #      assert asset.txid == ChainAssets.check_db(asset.txid, asset.time)
+  #      #assert asset.txid == ChainAssets.check_db("randomvalue", asset.time)
+  #    end
+  #  end
+
+  test "get_assets_stats/0" do
+    insert(:asset)
+    assert %{assets_addresses: _, assets_transactions: _} = ChainAssets.get_assets_stats()
+  end
+end

--- a/apps/neoscan/test/helpers/helpers_test.exs
+++ b/apps/neoscan/test/helpers/helpers_test.exs
@@ -1,0 +1,83 @@
+defmodule Neoscan.Helpers.HelperTest do
+  use Neoscan.DataCase
+
+  alias Neoscan.Helpers
+
+  test "populate_groups/2" do
+    address_list = [{%{:address => "address1"}, nil}]
+
+    assert [{{%{address: "address1"}, nil}, "vins"}] ==
+             Helpers.populate_groups([{"address1", "vins"}], address_list)
+  end
+
+  test "map_vins/1" do
+    assert [] == Helpers.map_vins(nil)
+    assert [] == Helpers.map_vins([])
+    assert ["address1"] == Helpers.map_vins([%{"address_hash" => "address1"}])
+    assert ["address1"] == Helpers.map_vins([%{address_hash: "address1"}])
+  end
+
+  test "map_vouts/1" do
+    assert [] == Helpers.map_vouts(nil)
+    assert [] == Helpers.map_vouts([])
+    assert ["address1"] == Helpers.map_vouts([%{"address" => "address1"}])
+    assert ["address1"] == Helpers.map_vouts([%{address_hash: "address1"}])
+  end
+
+  # TODO: probably need to refactor the 3 following functions
+  test "check_if_attrs_balance_exists/1" do
+    assert Helpers.check_if_attrs_balance_exists(%{balance: :something})
+    assert not Helpers.check_if_attrs_balance_exists(%{})
+  end
+
+  test "check_if_attrs_txids_exists/1" do
+    assert Helpers.check_if_attrs_txids_exists(%{tx_ids: :something})
+    assert not Helpers.check_if_attrs_txids_exists(%{})
+  end
+
+  test "check_if_attrs_claimed_exists/1" do
+    assert Helpers.check_if_attrs_claimed_exists(%{claimed: :something})
+    assert not Helpers.check_if_attrs_claimed_exists(%{})
+  end
+
+  test "substitute_if_updated/3" do
+    assert {
+             %{:address => "address1"},
+             %{
+               "hello" => "world"
+             }
+           } ==
+             Helpers.substitute_if_updated(%{address: "address1"}, %{}, [
+               {%{:address => "address1"}, %{"hello" => "world"}}
+             ])
+
+    assert {
+             %{:address => "address2"},
+             %{}
+           } ==
+             Helpers.substitute_if_updated(%{address: "address2"}, %{}, [
+               {%{:address => "address1"}, %{"hello" => "world"}}
+             ])
+  end
+
+  test "round_or_not/1" do
+    assert 12.3 == Helpers.round_or_not(12.3)
+    assert 12 == Helpers.round_or_not(12)
+    assert 12.3 == Helpers.round_or_not("12.3")
+  end
+
+  test "contract?/1" do
+    assert not Helpers.contract?(
+             "1234567890123456789012345678901234567890123456789012345678901234"
+           )
+
+    assert Helpers.contract?("12")
+  end
+
+  test "apply_precision/3" do
+    assert "1.234567e-6" ==
+             Helpers.apply_precision(1_234_567, "1234567890123456789012345678901234567890", 12)
+
+    assert "1234567" == Helpers.apply_precision(1_234_567, "1", 12)
+  end
+end


### PR DESCRIPTION
### tests
- added 37 tests for neoscan
- add tests for chain_assets, blocks, balance_histories, helpers
- coverage from 31.4% to 43.5%

### refactoring
- delete useless/buggy? `Blocks.change_block/1`
- fix return value of `Blocks.delete_blocks/1`
- simplify `Assets.get_token_by_contract/1` (Enum.each always return :ok)
- simplify `Assets.get_asset_name_by_hash/1` (cond do should not be used if only true or false)
- simplify `Assets.get_asset_precision_by_hash/1` (cond do should not be used if only true or false)
- simplify `Assets.filter_name/1`
- simplify `Helpers.contract?/1`
