### PR TITLE
do not start monitor and sync application during test

### DIFF
--- a/apps/neoscan_monitor/config/config.exs
+++ b/apps/neoscan_monitor/config/config.exs
@@ -58,3 +58,5 @@ config :neoscan_monitor,
     "http://seed8.concierge.io:10332",
     "http://seed9.concierge.io:10332"
   ]
+
+config :neoscan_monitor, should_start: Mix.env() not in [:travis, :test]

--- a/apps/neoscan_monitor/lib/neoscan_monitor/application.ex
+++ b/apps/neoscan_monitor/lib/neoscan_monitor/application.ex
@@ -5,13 +5,13 @@ defmodule NeoscanMonitor.Application do
 
   use Application
 
+  @should_start Application.get_env(:neoscan_monitor, :should_start)
+
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     # Define workers and child supervisors to be supervised
     children = [
-      # Starts a worker by calling:
-      # NeoscanMonitor.Worker.start_link(arg1, arg2, arg3)
       worker(NeoscanMonitor.Server, []),
       worker(NeoscanMonitor.Worker, [])
     ]
@@ -19,6 +19,6 @@ defmodule NeoscanMonitor.Application do
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: NeoscanMonitor.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(if(@should_start, do: children, else: []), opts)
   end
 end

--- a/apps/neoscan_sync/config/config.exs
+++ b/apps/neoscan_sync/config/config.exs
@@ -17,3 +17,5 @@ config :neoscan_sync,
   start_notifications: 1_444_800,
   # genstage demand size
   demand_size: 150
+
+config :neoscan_sync, should_start: Mix.env() not in [:travis, :test]

--- a/apps/neoscan_sync/lib/neoscan_sync/application.ex
+++ b/apps/neoscan_sync/lib/neoscan_sync/application.ex
@@ -5,23 +5,20 @@ defmodule NeoscanSync.Application do
 
   use Application
 
+  @should_start Application.get_env(:neoscan_sync, :should_start)
+
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     # Define workers and child supervisors to be supervised
     children = [
-      # worker(NeoscanSync.FastSync,[], [restart: :permanent,
-      #                                 max_restarts: 30, max_seconds: 10]),
       worker(NeoscanSync.Producer, []),
       worker(NeoscanSync.Consumer, [])
-      # Starts a worker by calling:
-      # NEOScanSync.Worker.start_link(arg1, arg2, arg3)
-      # worker(NEOScanSync.Worker, [arg1, arg2, arg3]),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_all, name: NeoscanSync.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(if(@should_start, do: children, else: []), opts)
   end
 end


### PR DESCRIPTION
I suggest that during unit testing we do not start monitor and sync application of the umbrella app. The reason is that it runs in the background and slow down the tests, it might also introduce unexpected behavior during testing (insertion in the db/connection errors).

We can restore it when tests for monitor/sync apps are ready.