### PR TITLE
improve query to use index

### DIFF
--- a/apps/neoscan/lib/neoscan/blocks/blocks.ex
+++ b/apps/neoscan/lib/neoscan/blocks/blocks.ex
@@ -327,10 +327,7 @@ defmodule Neoscan.Blocks do
         e in Block,
         select: e.index,
         where: e.index > -1,
-        # force postgres to use index
-        order_by: [
-          desc: e.index
-        ],
+        order_by: [fragment("? DESC NULLS LAST", e.index)],
         limit: 1
       )
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3918750/39965608-93bed152-56c6-11e8-85d6-17aa7eb24743.png)

Change the code to use `ORDER BY index DESC NULLS LAST` instead of `ORDER BY index DESC`