### PR TITLE
parallelize transaction processing

### DIFF
--- a/apps/neoscan/lib/neoscan/transactions/transactions.ex
+++ b/apps/neoscan/lib/neoscan/transactions/transactions.ex
@@ -633,12 +633,13 @@ defmodule Neoscan.Transactions do
 
   """
   def create_transactions(block, transactions) do
-    case Enum.each(transactions, fn transaction -> create_transaction(block, transaction) end) do
-      :ok ->
-        {:ok, "Created", block}
+    pmap(transactions, fn transaction -> create_transaction(block, transaction) end)
+    {:ok, "Created", block}
+  end
 
-      _ ->
-        {:error, "failed to create transactions"}
-    end
+  defp pmap(collection, func) do
+    collection
+    |> Enum.map(&Task.async(fn -> func.(&1) end))
+    |> Enum.map(&Task.await(&1, 60_000))
   end
 end


### PR DESCRIPTION
After profiling the speed of the the function add_block, I found the main bottleneck for insertion was located on the `Transactions.create_transactions(transactions)` line. For each transaction in the block, the function `create_transaction` will be called, instead of doing it serially we can make this in parallel, the time being spent for block insertion is then reduced by n where n is the number of transaction (~10).

@lucianoengel please confirm this operation can be done in parallel and that it does not impact the logic. Also, how much transactions can have a node, if this number is high it might be troublesome.