### PR TITLE
remove query to cache assets

### DIFF
--- a/apps/neoscan_cache/lib/neoscan_cache/cache.ex
+++ b/apps/neoscan_cache/lib/neoscan_cache/cache.ex
@@ -117,7 +117,7 @@ defmodule NeoscanCache.Cache do
     transfers = Transfers.home_transfers()
 
     assets = ChainAssets.list_assets()
-#      |> Utils.get_stats()
+    #      |> Utils.get_stats()
 
     stats = Utils.get_general_stats()
 

--- a/apps/neoscan_cache/lib/neoscan_cache/cache.ex
+++ b/apps/neoscan_cache/lib/neoscan_cache/cache.ex
@@ -10,6 +10,7 @@ defmodule NeoscanCache.Cache do
   alias Neoscan.Transactions
   alias Neoscan.Transfers
   alias Neoscan.Addresses
+  alias Neoscan.ChainAssets
   alias Neoprice.NeoBtc
   alias Neoprice.NeoUsd
   alias Neoprice.GasBtc
@@ -115,11 +116,8 @@ defmodule NeoscanCache.Cache do
 
     transfers = Transfers.home_transfers()
 
-#    assets =
-#      ChainAssets.list_assets()
+    assets = ChainAssets.list_assets()
 #      |> Utils.get_stats()
-
-    assets = []
 
     stats = Utils.get_general_stats()
 

--- a/apps/neoscan_cache/lib/neoscan_cache/cache.ex
+++ b/apps/neoscan_cache/lib/neoscan_cache/cache.ex
@@ -10,7 +10,6 @@ defmodule NeoscanCache.Cache do
   alias Neoscan.Transactions
   alias Neoscan.Transfers
   alias Neoscan.Addresses
-  alias Neoscan.ChainAssets
   alias Neoprice.NeoBtc
   alias Neoprice.NeoUsd
   alias Neoprice.GasBtc

--- a/apps/neoscan_cache/lib/neoscan_cache/cache.ex
+++ b/apps/neoscan_cache/lib/neoscan_cache/cache.ex
@@ -116,9 +116,11 @@ defmodule NeoscanCache.Cache do
 
     transfers = Transfers.home_transfers()
 
-    assets =
-      ChainAssets.list_assets()
-      |> Utils.get_stats()
+#    assets =
+#      ChainAssets.list_assets()
+#      |> Utils.get_stats()
+
+    assets = []
 
     stats = Utils.get_general_stats()
 


### PR DESCRIPTION
Querying cache assets every 5 seconds is resource intensive and it might slow down other requests.
As the page is not used anymore, I commented this request.