### PR TITLE
use yield instead of await

### DIFF
--- a/apps/neoscan_node/lib/neoscan_node/worker.ex
+++ b/apps/neoscan_node/lib/neoscan_node/worker.ex
@@ -39,10 +39,13 @@ defmodule NeoscanNode.Worker do
   def load do
     data =
       get_servers()
-      |> pmap(fn url ->
-        current_height = Blockchain.get_current_height(url)
-        {url, current_height, evaluate_result(url, current_height)}
-      end, 15_000)
+      |> pmap(
+        fn url ->
+          current_height = Blockchain.get_current_height(url)
+          {url, current_height, evaluate_result(url, current_height)}
+        end,
+        15_000
+      )
       |> Enum.filter(fn {_, _, keep} -> keep end)
       |> Enum.map(fn {url, {:ok, height}, _} -> {url, height} end)
 


### PR DESCRIPTION
Right now neoscan_node can crash because the asynchronous task to check block height of different node might take more time than the value of the await timeout. To solve this problem we can use the yield function that will cancel tasks taking too much time