### PR TITLE
delegate ets table creation to a dedicated process

### DIFF
--- a/apps/neoprice/lib/neoprice.ex
+++ b/apps/neoprice/lib/neoprice.ex
@@ -6,12 +6,14 @@ defmodule Neoprice do
   alias Neoprice.NeoUsd
   alias Neoprice.GasBtc
   alias Neoprice.GasUsd
+  alias Neoprice.EtsProcess
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     # Define workers and child supervisors to be supervised
     children = [
+      worker(EtsProcess, []),
       NeoBtc.worker(),
       NeoUsd.worker(),
       GasBtc.worker(),

--- a/apps/neoprice/lib/neoprice/cache.ex
+++ b/apps/neoprice/lib/neoprice/cache.ex
@@ -5,6 +5,7 @@ defmodule Neoprice.Cache do
 
   use GenServer
   alias Neoprice.Cryptocompare
+  alias Neoprice.EtsProcess
   require Logger
 
   @minute 60
@@ -58,7 +59,7 @@ defmodule Neoprice.Cache do
 
   def init(state) do
     Enum.each(state.module.config, fn cache ->
-      :ets.new(cache.cache_name, [:public, :ordered_set, :named_table, {:read_concurrency, true}])
+      EtsProcess.create_table(cache.cache_name)
     end)
 
     Process.send_after(self(), :sync, 0)

--- a/apps/neoprice/lib/neoprice/ets_process.ex
+++ b/apps/neoprice/lib/neoprice/ets_process.ex
@@ -1,0 +1,27 @@
+defmodule Neoprice.EtsProcess do
+  use GenServer
+
+  # Callbacks
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:ok, %{}}
+  end
+
+  def create_table(name) do
+    GenServer.call(__MODULE__, {:create, name})
+  end
+
+  @impl true
+  def handle_call({:create, name}, _from, state) do
+    unless name in :ets.all() do
+      :ets.new(name, [:public, :ordered_set, :named_table, {:read_concurrency, true}])
+    end
+
+    {:reply, :ok, state}
+  end
+end

--- a/apps/neoscan_cache/lib/neoscan_cache/application.ex
+++ b/apps/neoscan_cache/lib/neoscan_cache/application.ex
@@ -4,13 +4,16 @@ defmodule NeoscanCache.Application do
   @moduledoc false
 
   use Application
+  alias NeoscanCache.EtsProcess
+  alias NeoscanCache.Cache
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     # Define workers and child supervisors to be supervised
     children = [
-      worker(NeoscanCache.Cache, [])
+      worker(EtsProcess, []),
+      worker(Cache, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/neoscan_cache/lib/neoscan_cache/cache.ex
+++ b/apps/neoscan_cache/lib/neoscan_cache/cache.ex
@@ -16,6 +16,7 @@ defmodule NeoscanCache.Cache do
   alias Neoprice.GasBtc
   alias Neoprice.GasUsd
   alias Neoscan.Claims.Unclaimed
+  alias NeoscanCache.EtsProcess
 
   require Logger
 
@@ -27,14 +28,7 @@ defmodule NeoscanCache.Cache do
   # run initial queries and fill state with all info needed in the app,
   # then sends message with new state to server module
   def init(:ok) do
-    :ets.new(__MODULE__, [
-      :set,
-      :named_table,
-      :public,
-      read_concurrency: true,
-      write_concurrency: true
-    ])
-
+    EtsProcess.create_table(__MODULE__)
     Process.send_after(self(), :broadcast, 30_000)
     Process.send(self(), :repair, [])
     {:ok, sync(%{tokens: []})}

--- a/apps/neoscan_cache/lib/neoscan_cache/ets_process.ex
+++ b/apps/neoscan_cache/lib/neoscan_cache/ets_process.ex
@@ -1,0 +1,33 @@
+defmodule NeoscanCache.EtsProcess do
+  use GenServer
+
+  # Callbacks
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:ok, %{}}
+  end
+
+  def create_table(name) do
+    GenServer.call(__MODULE__, {:create, name})
+  end
+
+  @impl true
+  def handle_call({:create, name}, _from, state) do
+    unless name in :ets.all() do
+      :ets.new(name, [
+        :set,
+        :named_table,
+        :public,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+    end
+
+    {:reply, :ok, state}
+  end
+end

--- a/apps/neoscan_node/lib/neoscan_node/application.ex
+++ b/apps/neoscan_node/lib/neoscan_node/application.ex
@@ -5,11 +5,17 @@ defmodule NeoscanNode.Application do
 
   use Application
 
+  alias NeoscanNode.Worker
+  alias NeoscanNode.EtsProcess
+
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     # Define workers and child supervisors to be supervised
-    children = [worker(NeoscanNode.Worker, [])]
+    children = [
+      worker(EtsProcess, []),
+      worker(Worker, [])
+    ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options

--- a/apps/neoscan_node/lib/neoscan_node/ets_process.ex
+++ b/apps/neoscan_node/lib/neoscan_node/ets_process.ex
@@ -1,0 +1,33 @@
+defmodule NeoscanNode.EtsProcess do
+  use GenServer
+
+  # Callbacks
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:ok, %{}}
+  end
+
+  def create_table(name) do
+    GenServer.call(__MODULE__, {:create, name})
+  end
+
+  @impl true
+  def handle_call({:create, name}, _from, state) do
+    unless name in :ets.all() do
+      :ets.new(name, [
+        :set,
+        :named_table,
+        :public,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+    end
+
+    {:reply, :ok, state}
+  end
+end

--- a/apps/neoscan_node/lib/neoscan_node/worker.ex
+++ b/apps/neoscan_node/lib/neoscan_node/worker.ex
@@ -8,6 +8,7 @@ defmodule NeoscanNode.Worker do
   @update_interval 10_000
 
   alias NeoscanNode.Blockchain
+  alias NeoscanNode.EtsProcess
 
   use GenServer
 
@@ -117,16 +118,8 @@ defmodule NeoscanNode.Worker do
   end
 
   def init(:ok) do
-    :ets.new(__MODULE__, [
-      :set,
-      :named_table,
-      :public,
-      read_concurrency: true,
-      write_concurrency: true
-    ])
-
+    EtsProcess.create_table(__MODULE__)
     sync()
-
     {:ok, nil}
   end
 end


### PR DESCRIPTION
When an ets table is created, it is linked with the process creating it, if this process crash then the content of the ets table is also removed and a new table is created. This is a problem because ets table are only used as a cache purpose, there is then no reason for making it crash if for example an http request has timeout. In the current setup a http timeout could lead to the neoscan_node table to be empty, if a request from the rest of the app needs a value in cache to perform an operation it will crash as well as the ets table is not available. from a trivial http timeout to update the neo price cache we can then go to a full app crash. This PR solves this.