### PR TITLE
add 10 seconds cache with con_cache

### DIFF
--- a/apps/neoscan_web/lib/neoscan_web/application.ex
+++ b/apps/neoscan_web/lib/neoscan_web/application.ex
@@ -9,6 +9,14 @@ defmodule NeoscanWeb.Application do
     # Define workers and child supervisors to be supervised
     children = [
       # Start the endpoint when the application starts
+      {
+        ConCache,
+        [
+          name: :my_cache,
+          ttl_check_interval: :timer.seconds(1),
+          global_ttl: :timer.seconds(5)
+        ]
+      },
       supervisor(Endpoint, [])
       # Start your own worker by calling:
       # NeoscanWeb.Worker.start_link(arg1, arg2, arg3)

--- a/apps/neoscan_web/lib/neoscan_web/controllers/api_controller.ex
+++ b/apps/neoscan_web/lib/neoscan_web/controllers/api_controller.ex
@@ -4,43 +4,56 @@ defmodule NeoscanWeb.ApiController do
   alias Neoscan.Api
   alias NeoscanCache.Api, as: CacheApi
 
+  defmacro cache(key, value, ttl \\ 10_000) do
+    quote do
+      ConCache.get_or_store(:my_cache, unquote(key), fn ->
+        %ConCache.Item{value: unquote(value), ttl: unquote(ttl)}
+      end)
+    end
+  end
+
   def get_balance(conn, %{"hash" => hash}) do
-    balance = Api.get_balance(hash)
+    balance = cache({:get_balance, hash}, Api.get_balance(hash))
     json(conn, balance)
   end
 
   def get_claimed(conn, %{"hash" => hash}) do
-    claimed = Api.get_claimed(hash)
+    claimed = cache({:get_claimed, hash}, Api.get_claimed(hash))
     json(conn, claimed)
   end
 
   def get_unclaimed(conn, %{"hash" => hash}) do
-    unclaimed = Api.get_unclaimed(hash)
+    unclaimed = cache({:get_unclaimed, hash}, Api.get_unclaimed(hash))
     json(conn, unclaimed)
   end
 
   def get_claimable(conn, %{"hash" => hash}) do
-    claimable = Api.get_claimable(hash)
+    claimable = cache({:get_claimable, hash}, Api.get_claimable(hash))
     json(conn, claimable)
   end
 
   def get_address(conn, %{"hash" => hash}) do
-    address = Api.get_address(hash)
+    address = cache({:get_address, hash}, Api.get_address(hash))
     json(conn, address)
   end
 
   def get_address_neon(conn, %{"hash" => hash}) do
-    address = Api.get_address_neon(hash)
+    address = cache({:get_address_neon, hash}, Api.get_address_neon(hash))
     json(conn, address)
   end
 
   def get_address_abstracts(conn, %{"hash" => hash, "page" => page}) do
-    abstracts = Api.get_address_abstracts(hash, page)
+    abstracts = cache({:get_address_abstracts, hash, page}, Api.get_address_abstracts(hash, page))
     json(conn, abstracts)
   end
 
   def get_address_to_address_abstracts(conn, %{"hash1" => hash1, "hash2" => hash2, "page" => page}) do
-    abstracts = Api.get_address_to_address_abstracts(hash1, hash2, page)
+    abstracts =
+      cache(
+        {:get_address_to_address_abstracts, hash1, hash2, page},
+        Api.get_address_to_address_abstracts(hash1, hash2, page)
+      )
+
     json(conn, abstracts)
   end
 
@@ -57,67 +70,71 @@ defmodule NeoscanWeb.ApiController do
   end
 
   def get_asset(conn, %{"hash" => hash}) do
-    asset = Api.get_asset(hash)
+    asset = cache({:get_asset, hash}, Api.get_asset(hash))
     json(conn, asset)
   end
 
   def get_block(conn, %{"hash" => hash}) do
-    block = Api.get_block(hash)
+    block = cache({:get_block, hash}, Api.get_block(hash))
     json(conn, block)
   end
 
   def get_last_blocks(conn, _params) do
-    blocks = Api.get_last_blocks()
+    blocks = cache({:get_last_blocks}, Api.get_last_blocks())
     json(conn, blocks)
   end
 
   def get_highest_block(conn, _params) do
-    block = Api.get_highest_block()
+    block = cache({:get_highest_block}, Api.get_highest_block())
     json(conn, block)
   end
 
   def get_transaction(conn, %{"hash" => hash}) do
-    transaction = Api.get_transaction(hash)
+    transaction = cache({:get_transaction, hash}, Api.get_transaction(hash))
     json(conn, transaction)
   end
 
   def get_last_transactions(conn, %{"type" => type}) do
-    transactions = Api.get_last_transactions(type)
+    transactions = cache({:get_last_transactions, type}, Api.get_last_transactions(type))
     json(conn, transactions)
   end
 
   def get_last_transactions(conn, %{}) do
-    transactions = Api.get_last_transactions(nil)
+    transactions = cache({:get_last_transactions}, Api.get_last_transactions(nil))
     json(conn, transactions)
   end
 
   def get_last_transactions_by_address(conn, %{"hash" => hash, "page" => page}) do
-    transactions = Api.get_last_transactions_by_address(hash, page)
+    transactions =
+      cache(
+        {:get_last_transactions_by_address, hash, page},
+        Api.get_last_transactions_by_address(hash, page)
+      )
+
     json(conn, transactions)
   end
 
   def get_last_transactions_by_address(conn, %{"hash" => hash}) do
-    transactions = Api.get_last_transactions_by_address(hash, 1)
-    json(conn, transactions)
+    get_last_transactions_by_address(conn, %{"hash" => hash, "page" => 1})
   end
 
   def get_all_nodes(conn, %{}) do
-    nodes = Api.get_all_nodes()
+    nodes = cache({:get_all_nodes}, Api.get_all_nodes())
     json(conn, nodes)
   end
 
   def get_nodes(conn, %{}) do
-    nodes = Api.get_nodes()
+    nodes = cache({:get_nodes}, Api.get_nodes())
     json(conn, nodes)
   end
 
   def get_height(conn, %{}) do
-    height = Api.get_height()
+    height = cache({:get_height}, Api.get_height())
     json(conn, height)
   end
 
   def get_fees_in_range(conn, %{"range" => range}) do
-    fees = Api.get_fees_in_range(range)
+    fees = cache({:get_fees_in_range, range}, Api.get_fees_in_range(range))
     json(conn, fees)
   end
 

--- a/apps/neoscan_web/mix.exs
+++ b/apps/neoscan_web/mix.exs
@@ -10,7 +10,9 @@ defmodule NeoscanWeb.Mixfile do
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: "~> 1.4",
-      elixirc_options: [warnings_as_errors: true],
+      elixirc_options: [
+        warnings_as_errors: true
+      ],
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [
         tool: ExCoveralls
@@ -52,6 +54,7 @@ defmodule NeoscanWeb.Mixfile do
       {:phoenix_ecto, "~> 3.2"},
       {:phoenix_html, "~> 2.10"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
+      {:con_cache, "~> 0.13.0"},
       {:gettext, "~> 0.11"},
       {:neoscan, in_umbrella: true},
       {:neoprice, in_umbrella: true},

--- a/apps/neoscan_web/test/neoscan_web/controllers/api_controller_test.exs
+++ b/apps/neoscan_web/test/neoscan_web/controllers/api_controller_test.exs
@@ -110,8 +110,21 @@ defmodule NeoscanWeb.ApiControllerTest do
     insert(:block)
     insert(:block)
     conn = get(conn, "/api/main_net/v1/get_last_blocks")
-
     assert 2 == Enum.count(json_response(conn, 200))
+  end
+
+  test "test concache", %{conn: conn} do
+    insert(:block)
+    insert(:block)
+    conn = get(conn, "/api/main_net/v1/get_last_blocks")
+    assert 2 == Enum.count(json_response(conn, 200))
+    insert(:block)
+    conn = get(conn, "/api/main_net/v1/get_last_blocks")
+    assert 2 == Enum.count(json_response(conn, 200))
+    Supervisor.terminate_child(NeoscanWeb.Supervisor, ConCache)
+    Supervisor.restart_child(NeoscanWeb.Supervisor, ConCache)
+    conn = get(conn, "/api/main_net/v1/get_last_blocks")
+    assert 3 == Enum.count(json_response(conn, 200))
   end
 
   test "get_highest_block", %{conn: conn} do

--- a/apps/neoscan_web/test/neoscan_web/controllers/api_controller_test.exs
+++ b/apps/neoscan_web/test/neoscan_web/controllers/api_controller_test.exs
@@ -3,6 +3,12 @@ defmodule NeoscanWeb.ApiControllerTest do
 
   import NeoscanWeb.Factory
 
+  setup do
+    Supervisor.terminate_child(NeoscanWeb.Supervisor, ConCache)
+    Supervisor.restart_child(NeoscanWeb.Supervisor, ConCache)
+    :ok
+  end
+
   test "get_balance/:hash", %{conn: conn} do
     address =
       insert(:address, %{

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
+  "con_cache": {:hex, :con_cache, "0.13.0", "fe30eeffc776465b596a60d5bc7f81083fd90aeeeb5d72b98a957fb4a78e4378", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cors_plug": {:hex, :cors_plug, "1.5.2", "72df63c87e4f94112f458ce9d25800900cc88608c1078f0e4faddf20933eda6e", [:mix], [{:plug, "~> 1.3 or ~> 1.4 or ~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
In order to limit queries to the database we can use a cache at the neoscan_web app level. For each API endpoint we can create a cache key {:method, args}, e.g.: {:get_address, hash}. The cache ttl is set to 10 seconds but can be modified for each endpoint