### PR TITLE
change order by to leverage existing index

### DIFF
--- a/apps/neoscan/lib/neoscan/api/api.ex
+++ b/apps/neoscan/lib/neoscan/api/api.ex
@@ -691,9 +691,7 @@ defmodule Neoscan.Api do
     query =
       from(
         e in Block,
-        order_by: [
-          desc: e.index
-        ],
+        order_by: [fragment("? DESC NULLS LAST", e.index)],
         preload: [
           transactions: ^tran_query,
           transfers: ^trans_query
@@ -742,9 +740,7 @@ defmodule Neoscan.Api do
     query =
       from(
         e in Block,
-        order_by: [
-          desc: e.index
-        ],
+        order_by: [fragment("? DESC NULLS LAST", e.index)],
         preload: [
           transactions: ^tran_query,
           transfers: ^trans_query


### PR DESCRIPTION
After quick manual testing on the staging API, I realized two more bock query are not leveraging the index, this is now fixed. `get_highest_block` and `get_last_blocks` end point would take more than 10 seconds to return the value because it was doing a sequential scan of the db. Now the response time should be lowered in the ms range