### PR TITLE
Remove check origin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,8 @@ neoscan-build:
     - docker build -t $REGISTRY_PATH .
     - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker push $REGISTRY_PATH
+    - if [[ $CI_COMMIT_REF_SLUG == *"master"* ]]; then docker tag $REGISTRY_PATH $CI_REGISTRY_IMAGE; fi
+    - if [[ $CI_COMMIT_REF_SLUG == *"master"* ]]; then docker push $CI_REGISTRY_IMAGE; fi
 
 haproxy-build:
   stage: build

--- a/apps/neoscan_web/config/prod.exs
+++ b/apps/neoscan_web/config/prod.exs
@@ -25,15 +25,7 @@ config :neoscan_web, NeoscanWeb.Endpoint,
   ],
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,
-  secret_key_base: "J8EWtXVVWp+AmNn4fmdodz17pug1X8v8QbjiPnNf0IkeFYhY140Dhei7UGUACHXs",
-  check_origin: [
-    "https://neoscan.io",
-    "https://www.neoscan.io",
-    "https://api.neoscan.io",
-    "https://neoscan.backslash.fr",
-    "https://neoscanprod.backslash.fr",
-    "//neoscanlocal.com"
-  ]
+  secret_key_base: "J8EWtXVVWp+AmNn4fmdodz17pug1X8v8QbjiPnNf0IkeFYhY140Dhei7UGUACHXs"
 
 # ## SSL Support
 #


### PR DESCRIPTION
to simplify the configuration we can remove the check_origin parameter to automatically check the HOST variable instead. 

gitlab-ci.yml was modified to add a latest tag for the latest master release