### PR TITLE
Cache total sys fee

### DIFF
--- a/apps/neoscan/lib/neoscan/application.ex
+++ b/apps/neoscan/lib/neoscan/application.ex
@@ -9,13 +9,18 @@ defmodule Neoscan.Application do
   """
   use Application
 
+  alias Neoscan.Blocks.BlocksCache
+
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    children = [
+      worker(BlocksCache, []),
+      supervisor(Neoscan.Repo, [])
+    ]
+
     Supervisor.start_link(
-      [
-        supervisor(Neoscan.Repo, [])
-      ],
+      children,
       strategy: :one_for_one,
       name: Neoscan.Supervisor
     )

--- a/apps/neoscan/lib/neoscan/blocks/blocks.ex
+++ b/apps/neoscan/lib/neoscan/blocks/blocks.ex
@@ -430,6 +430,18 @@ defmodule Neoscan.Blocks do
       "wrong input string can't be parsed into integer"
   end
 
+  def get_total_sys_fee(min, max) do
+    query =
+      from(
+        b in Block,
+        where: b.index >= ^min and b.index <= ^max,
+        select: map(b, [:index, :total_sys_fee]),
+        order_by: :index
+      )
+
+    Repo.all(query)
+  end
+
   def compute_fees(block) do
     sys_fee =
       Enum.reduce(block["tx"], 0, fn tx, acc ->

--- a/apps/neoscan/lib/neoscan/blocks/blocks_cache.ex
+++ b/apps/neoscan/lib/neoscan/blocks/blocks_cache.ex
@@ -1,0 +1,106 @@
+defmodule Neoscan.Blocks.BlocksCache do
+  @moduledoc """
+  Provide a cache for the block fees, it uses a binary structure stored in a file for efficiency reason.
+  """
+
+  use GenServer
+  alias Neoscan.Blocks
+
+  @filename "./block_cache"
+  @integer_byte_size 4
+  @integer_bit_size 8 * @integer_byte_size
+  @nb_cached_blocks 10_000_000
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    init_file_cache()
+    init_ets_table()
+    set(:min, nil)
+    set(:max, nil)
+    {:ok, %{}}
+  end
+
+  defp init_file_cache do
+    {:ok, file} = :file.open(@filename, [:raw, :write])
+    total_size = @integer_byte_size * @nb_cached_blocks
+    :file.write(file, <<0 :: size(total_size)>>)
+    :file.close(file)
+  end
+
+  defp init_ets_table do
+    :ets.new(
+      __MODULE__,
+      [
+        :set,
+        :named_table,
+        :public,
+        read_concurrency: true,
+        write_concurrency: true
+      ]
+    )
+  end
+
+  defp set_cached_response(min, response) do
+    binary = response_to_binary(response)
+    {:ok, file} = :file.open(@filename, [:raw, :append])
+    :file.pwrite(file, @integer_byte_size * min, binary)
+    :file.close(file)
+    :ok
+  end
+
+  defp response_to_binary(response), do: response_to_binary(response, <<>>)
+  defp response_to_binary([], acc), do: acc
+  defp response_to_binary([%{total_sys_fee: fee} | t], acc) do
+    response_to_binary(t, <<acc :: binary, round(fee) :: size(@integer_bit_size)>>)
+  end
+
+  defp get_cached_response(min, max) do
+    {:ok, file} = :file.open(@filename, [:raw, :read, :binary])
+    {:ok, binary} = :file.pread(file, @integer_byte_size * min, @integer_byte_size * max)
+    :file.close(file)
+    binary_to_response(binary, min)
+  end
+
+  defp binary_to_response(binary, index), do: binary_to_response(binary, index, [])
+  defp binary_to_response(<<>>, _, acc), do: Enum.reverse(acc)
+  defp binary_to_response(<<fee :: size(@integer_bit_size), rest :: binary>>, index, acc) do
+    binary_to_response(rest, index + 1, [%{index: index, total_sys_fee: fee * 1.0} | acc])
+  end
+
+  defp get(key) do
+    case :ets.lookup(__MODULE__, key) do
+      [{^key, result}] -> result
+      _ -> nil
+    end
+  end
+
+  defp set(key, value) do
+    :ets.insert(__MODULE__, {key, value})
+  end
+
+  def get_total_sys_fee(_, -1), do: []
+  def get_total_sys_fee(min, max) do
+    cache_min = get(:min)
+    cache_max = get(:max)
+
+    uncached_ranges =   if is_nil(cache_max) or is_nil(cache_min) do
+      [{min, max}]
+    else
+      Enum.filter([{min, cache_min}, {cache_max, max}], fn ({a, b}) -> a < b end)
+    end
+
+    Enum.each(uncached_ranges, fn ({min, max}) -> set_cached_response(min, Blocks.get_total_sys_fee(min, max)) end)
+
+    #it is possible override will occur here, for example another process stores a smaller value of min
+    # or a higher value of max, however if data is queried again, it is not a serious problem, it would be better
+    # to update it atomically if and only if the value is lower or higher. But there is no easy way to do it wiht ets
+    set(:min, min)
+    set(:max, max)
+
+    get_cached_response(min, max)
+  end
+end

--- a/apps/neoscan/lib/neoscan/blocks/blocks_cache.ex
+++ b/apps/neoscan/lib/neoscan/blocks/blocks_cache.ex
@@ -27,21 +27,18 @@ defmodule Neoscan.Blocks.BlocksCache do
   defp init_file_cache do
     {:ok, file} = :file.open(@filename, [:raw, :write])
     total_size = @integer_byte_size * @nb_cached_blocks
-    :file.write(file, <<0 :: size(total_size)>>)
+    :file.write(file, <<0::size(total_size)>>)
     :file.close(file)
   end
 
   defp init_ets_table do
-    :ets.new(
-      __MODULE__,
-      [
-        :set,
-        :named_table,
-        :public,
-        read_concurrency: true,
-        write_concurrency: true
-      ]
-    )
+    :ets.new(__MODULE__, [
+      :set,
+      :named_table,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
   end
 
   defp set_cached_response(min, response) do
@@ -54,8 +51,9 @@ defmodule Neoscan.Blocks.BlocksCache do
 
   defp response_to_binary(response), do: response_to_binary(response, <<>>)
   defp response_to_binary([], acc), do: acc
+
   defp response_to_binary([%{total_sys_fee: fee} | t], acc) do
-    response_to_binary(t, <<acc :: binary, round(fee) :: size(@integer_bit_size)>>)
+    response_to_binary(t, <<acc::binary, round(fee)::size(@integer_bit_size)>>)
   end
 
   defp get_cached_response(min, max) do
@@ -67,7 +65,8 @@ defmodule Neoscan.Blocks.BlocksCache do
 
   defp binary_to_response(binary, index), do: binary_to_response(binary, index, [])
   defp binary_to_response(<<>>, _, acc), do: Enum.reverse(acc)
-  defp binary_to_response(<<fee :: size(@integer_bit_size), rest :: binary>>, index, acc) do
+
+  defp binary_to_response(<<fee::size(@integer_bit_size), rest::binary>>, index, acc) do
     binary_to_response(rest, index + 1, [%{index: index, total_sys_fee: fee * 1.0} | acc])
   end
 
@@ -83,19 +82,23 @@ defmodule Neoscan.Blocks.BlocksCache do
   end
 
   def get_total_sys_fee(_, -1), do: []
+
   def get_total_sys_fee(min, max) do
     cache_min = get(:min)
     cache_max = get(:max)
 
-    uncached_ranges =   if is_nil(cache_max) or is_nil(cache_min) do
-      [{min, max}]
-    else
-      Enum.filter([{min, cache_min}, {cache_max, max}], fn ({a, b}) -> a < b end)
-    end
+    uncached_ranges =
+      if is_nil(cache_max) or is_nil(cache_min) do
+        [{min, max}]
+      else
+        Enum.filter([{min, cache_min}, {cache_max, max}], fn {a, b} -> a < b end)
+      end
 
-    Enum.each(uncached_ranges, fn ({min, max}) -> set_cached_response(min, Blocks.get_total_sys_fee(min, max)) end)
+    Enum.each(uncached_ranges, fn {min, max} ->
+      set_cached_response(min, Blocks.get_total_sys_fee(min, max))
+    end)
 
-    #it is possible override will occur here, for example another process stores a smaller value of min
+    # it is possible override will occur here, for example another process stores a smaller value of min
     # or a higher value of max, however if data is queried again, it is not a serious problem, it would be better
     # to update it atomically if and only if the value is lower or higher. But there is no easy way to do it wiht ets
     set(:min, min)

--- a/apps/neoscan/lib/neoscan/claims/unclaimed.ex
+++ b/apps/neoscan/lib/neoscan/claims/unclaimed.ex
@@ -1,11 +1,10 @@
 defmodule Neoscan.Claims.Unclaimed do
   @moduledoc false
   import Ecto.Query, warn: false
-  alias Neoscan.Repo
   alias Neoscan.Repair
-  alias Neoscan.Vouts.Vout
-  alias Neoscan.Blocks.Block
+  alias Neoscan.Vouts
   alias Neoscan.Blocks
+  alias Neoscan.Blocks.BlocksCache
   alias Neoscan.BlockGasGeneration
 
   require Logger
@@ -15,14 +14,16 @@ defmodule Neoscan.Claims.Unclaimed do
 
   # calculate unclaimed gas bonus
   def calculate_bonus(address_id) do
-    get_unclaimed_vouts(address_id)
+    address_id
+    |> Vouts.get_unclaimed_vouts()
     |> add_end_height
     |> route_if_there_is_unclaimed
   end
 
   # calculate unclaimed gas bonus
   def calculate_vouts_bonus(address_id) do
-    get_unclaimed_vouts(address_id)
+    address_id
+    |> Vouts.get_unclaimed_vouts()
     |> filter_end_height
     |> route_if_there_is_unclaimed_but_dont_add
   end
@@ -102,20 +103,6 @@ defmodule Neoscan.Claims.Unclaimed do
     }
   end
 
-  # get all unclaimed transaction vouts
-  def get_unclaimed_vouts(address_id) do
-    query =
-      from(
-        v in Vout,
-        where:
-          v.address_id == ^address_id and v.claimed == false and
-            v.asset == "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
-        select: map(v, [:value, :start_height, :end_height, :n, :txid])
-      )
-
-    Repo.all(query)
-  end
-
   def add_end_height(unclaimed_vouts) do
     Enum.map(unclaimed_vouts, fn %{:end_height => height} = vout ->
       Map.put(vout, :end_height, check_end_height(height))
@@ -158,14 +145,7 @@ defmodule Neoscan.Claims.Unclaimed do
 
   # get total gas distribution amount for all blocks in a given range tuple
   def get_blocks_gas({min, max}) do
-    query =
-      from(
-        b in Block,
-        where: b.index >= ^min and b.index <= ^max,
-        select: map(b, [:index, :total_sys_fee])
-      )
-
-    Repo.all(query)
+    BlocksCache.get_total_sys_fee(min, max)
     |> Enum.map(fn %{:index => index, :total_sys_fee => sys} ->
       %{
         :index => index,

--- a/apps/neoscan/lib/neoscan/vouts/vouts.ex
+++ b/apps/neoscan/lib/neoscan/vouts/vouts.ex
@@ -174,4 +174,17 @@ defmodule Neoscan.Vouts do
       Map.put(vout, :value, Helpers.round_or_not(value))
     end)
   end
+
+  def get_unclaimed_vouts(address_id) do
+    query =
+      from(
+        v in Vout,
+        where:
+          v.address_id == ^address_id and v.claimed == false and
+          v.asset == "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+        select: map(v, [:value, :start_height, :end_height, :n, :txid])
+      )
+
+    Repo.all(query)
+  end
 end

--- a/apps/neoscan/lib/neoscan/vouts/vouts.ex
+++ b/apps/neoscan/lib/neoscan/vouts/vouts.ex
@@ -181,7 +181,7 @@ defmodule Neoscan.Vouts do
         v in Vout,
         where:
           v.address_id == ^address_id and v.claimed == false and
-          v.asset == "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
+            v.asset == "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b",
         select: map(v, [:value, :start_height, :end_height, :n, :txid])
       )
 

--- a/apps/neoscan/mix.exs
+++ b/apps/neoscan/mix.exs
@@ -47,7 +47,6 @@ defmodule Neoscan.Mixfile do
   defp deps do
     [
       {:postgrex, ">= 0.0.0"},
-      {:bitmap, "~> 1.0"},
       {:ecto, "~> 2.1"},
       {:ex_machina, "~> 2.0", only: :test},
       {:excoveralls, "~> 0.8", only: :test},

--- a/apps/neoscan/mix.exs
+++ b/apps/neoscan/mix.exs
@@ -47,6 +47,7 @@ defmodule Neoscan.Mixfile do
   defp deps do
     [
       {:postgrex, ">= 0.0.0"},
+      {:bitmap, "~> 1.0"},
       {:ecto, "~> 2.1"},
       {:ex_machina, "~> 2.0", only: :test},
       {:excoveralls, "~> 0.8", only: :test},

--- a/apps/neoscan/test/claims/unclaimed_test.exs
+++ b/apps/neoscan/test/claims/unclaimed_test.exs
@@ -4,27 +4,27 @@ defmodule Neoscan.Claims.UnclaimedTest do
   import Neoscan.Factory
 
   alias Neoscan.Claims.Unclaimed
-  #alias Neoscan.Blocks.BlocksCache
+  # alias Neoscan.Blocks.BlocksCache
   @asset "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b"
 
   test "calculate_bonus/0" do
-    #erase cache for consistency in results
+    # erase cache for consistency in results
     :ets.insert(Neoscan.Blocks.BlocksCache, {:min, nil})
     :ets.insert(Neoscan.Blocks.BlocksCache, {:max, nil})
 
     for x <- 1..100, do: insert(:block, %{index: x, total_sys_fee: x})
 
-    address = insert(
-      :address,
-      %{vouts: [insert(:vout, %{asset: @asset, start_height: 25, end_height: 75})]}
-    )
+    address =
+      insert(:address, %{
+        vouts: [insert(:vout, %{asset: @asset, start_height: 25, end_height: 75})]
+      })
 
     assert 0.0014375000000000002 == Unclaimed.calculate_bonus(address.id)
 
-    address = insert(
-      :address,
-      %{vouts: [insert(:vout, %{asset: @asset, start_height: 1, end_height: 100})]}
-    )
+    address =
+      insert(:address, %{
+        vouts: [insert(:vout, %{asset: @asset, start_height: 1, end_height: 100})]
+      })
 
     assert 0.0028710000000000003 == Unclaimed.calculate_bonus(address.id)
   end

--- a/apps/neoscan/test/claims/unclaimed_test.exs
+++ b/apps/neoscan/test/claims/unclaimed_test.exs
@@ -1,0 +1,31 @@
+defmodule Neoscan.Claims.UnclaimedTest do
+  use Neoscan.DataCase
+
+  import Neoscan.Factory
+
+  alias Neoscan.Claims.Unclaimed
+  #alias Neoscan.Blocks.BlocksCache
+  @asset "c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b"
+
+  test "calculate_bonus/0" do
+    #erase cache for consistency in results
+    :ets.insert(Neoscan.Blocks.BlocksCache, {:min, nil})
+    :ets.insert(Neoscan.Blocks.BlocksCache, {:max, nil})
+
+    for x <- 1..100, do: insert(:block, %{index: x, total_sys_fee: x})
+
+    address = insert(
+      :address,
+      %{vouts: [insert(:vout, %{asset: @asset, start_height: 25, end_height: 75})]}
+    )
+
+    assert 0.0014375000000000002 == Unclaimed.calculate_bonus(address.id)
+
+    address = insert(
+      :address,
+      %{vouts: [insert(:vout, %{asset: @asset, start_height: 1, end_height: 100})]}
+    )
+
+    assert 0.0028710000000000003 == Unclaimed.calculate_bonus(address.id)
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "approximate_histogram": {:hex, :approximate_histogram, "0.1.1", "198eb36681e763ed4baab6ca0682acec4ef642f60ba272f251d3059052f4f378", [:mix], []},
+  "bitmap": {:hex, :bitmap, "1.0.1", "37d913e4f36e65ffffc3e38ee2bd2e8d768aedec6973de4bdce5c3456ef8a86e", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},


### PR DESCRIPTION
Pghero shows an heavy usage of sys_fee and is constantly doing sequential scan on postgres to calculate unclaimed gas, in this pull request I implement a lazy cache to store locally the block fees.

![image](https://user-images.githubusercontent.com/3918750/40481928-355da902-5f7d-11e8-972b-ee9f78dbb404.png)
