### PR TITLE
Fix error handling logic in cryptocompare http calls

### DIFF
--- a/apps/neoprice/lib/neoprice/cryptocompare/api.ex
+++ b/apps/neoprice/lib/neoprice/cryptocompare/api.ex
@@ -10,8 +10,11 @@ defmodule Neoprice.Cryptocompare.Api do
   def last_price(from_symbol, to_symbol) do
     params = "fsym=#{from_symbol}&tsyms=#{to_symbol}"
     url = "https://" <> @url <> "/data/price?#{params}"
-    {:ok, %{status_code: 200, body: body}} = Helper.retry_get(url)
-
+    body = case Helper.retry_get(url) do
+      {:ok, %{status_code: 200, body: body}} -> body
+      _ -> {:error}
+    end
+    
     case Poison.decode(body) do
       {:ok, map} -> map[to_symbol]
       _ -> nil
@@ -21,14 +24,16 @@ defmodule Neoprice.Cryptocompare.Api do
   def last_price_full(from_symbol, to_symbol) do
     params = "fsyms=#{from_symbol}&tsyms=#{to_symbol}"
     url = "https://" <> @url <> "/data/pricemultifull?#{params}"
-    {:ok, %{status_code: 200, body: body}} = Helper.retry_get(url)
+    case Helper.retry_get(url) do
+      {:ok, %{status_code: 200, body: body}} ->
+        case Poison.decode(body) do
+          {:ok, map} ->
+            map["RAW"][from_symbol][to_symbol]
 
-    case Poison.decode(body) do
-      {:ok, map} ->
-        map["RAW"][from_symbol][to_symbol]
-
-      _ ->
-        nil
+          _ -> nil
+        end
+      
+      _ -> nil
     end
   end
 

--- a/apps/neoprice/lib/neoprice/cryptocompare/helper.ex
+++ b/apps/neoprice/lib/neoprice/cryptocompare/helper.ex
@@ -12,12 +12,20 @@ defmodule Neoprice.Cryptocompare.Helper do
 
   defp retry_get(url, n) do
     case HTTPPoisonWrapper.get(url) do
-      {:ok, _} = result ->
-        result
-
+      {:ok, %HTTPoison.Response{status_code: code}} = result -> 
+        case code do
+          x when x in 200..299 -> result
+          _ -> retry_get_handle_error(url, n)
+        end
+        
       _ ->
-        Process.sleep(@retry_interval * (@total_retry - n + 1))
-        retry_get(url, n - 1)
+        retry_get_handle_error(url, n)
     end
   end
+
+  defp retry_get_handle_error(url, n) do
+    Process.sleep(@retry_interval * (@total_retry - n + 1))
+    retry_get(url, n - 1)
+  end
+  
 end


### PR DESCRIPTION
I observed a crash in neoscan when a 500 was returned from a cryptocompare http call. This fixes the crash.