### PR TITLE
increase number of connection for front end and backend

### DIFF
--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -7,6 +7,7 @@ defaults
   timeout connect 5000ms                   # max time to wait for a connection attempt to a server to succeed
   timeout client 50000ms                   # max inactivity time on the client side
   timeout server 50000ms                   # max inactivity time on the server side
+  maxconn 8000
 
 backend neoscan                             # define a group of backend servers to handle legacy requests
   server api_server neoscan:4000      # add a server to this backend


### PR DESCRIPTION
After reaching 2000 open connection system was experiencing slowdown, it was due to a haproxy connection limit, this limit has been raised from 2000 to 8000.