### PR TITLE
Add a single release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ before_script:
   - export IMAGE_TAG="$CI_PIPELINE_ID-$CI_COMMIT_REF_SLUG"
   - export SYNC_REGISTRY_PATH="$CI_REGISTRY_IMAGE/sync:$IMAGE_TAG"
   - export API_REGISTRY_PATH="$CI_REGISTRY_IMAGE/api:$IMAGE_TAG"
+  - export FULL_REGISTRY_PATH="$CI_REGISTRY_IMAGE/full:$IMAGE_TAG"
 
 test:
   stage: test
@@ -67,9 +68,11 @@ build:
   - mix phx.digest
   - mix release --name=neoscan_sync --env=prod
   - mix release --name=neoscan_api --env=prod
-  - mkdir -p export/neoscan_sync && mkdir -p export/neoscan_api
+  - mix release --name=neoscan_full --env=prod
+  - mkdir -p export/neoscan_sync && mkdir -p export/neoscan_api && mkdir -p export/neoscan_full
   - RELEASE_DIR=`ls -d _build/prod/rel/neoscan_sync/releases/*/` && tar -xf "$RELEASE_DIR/neoscan_sync.tar.gz" -C export/neoscan_sync/
   - RELEASE_DIR=`ls -d _build/prod/rel/neoscan_api/releases/*/` && tar -xf "$RELEASE_DIR/neoscan_api.tar.gz" -C export/neoscan_api/
+  - RELEASE_DIR=`ls -d _build/prod/rel/neoscan_full/releases/*/` && tar -xf "$RELEASE_DIR/neoscan_full.tar.gz" -C export/neoscan_full/
   - rm -Rf _build/prod/lib/neo*
   artifacts:
     paths:
@@ -84,13 +87,17 @@ docker:
     - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker build --build-arg APP=neoscan_sync -t $SYNC_REGISTRY_PATH .
     - docker build --build-arg APP=neoscan_api -t $API_REGISTRY_PATH .
+    - docker build --build-arg APP=neoscan_full -t $FULL_REGISTRY_PATH .
     - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker push $SYNC_REGISTRY_PATH
     - docker push $API_REGISTRY_PATH
+    - docker push $FULL_REGISTRY_PATH
     - "[ \"$CI_COMMIT_REF_SLUG\" == \"master\" ] && docker tag $SYNC_REGISTRY_PATH $CI_REGISTRY_IMAGE/sync || true"
     - "[ \"$CI_COMMIT_REF_SLUG\" == \"master\" ] && docker tag $API_REGISTRY_PATH $CI_REGISTRY_IMAGE/api || true"
+    - "[ \"$CI_COMMIT_REF_SLUG\" == \"master\" ] && docker tag $FULL_REGISTRY_PATH $CI_REGISTRY_IMAGE/full || true"
     - "[ \"$CI_COMMIT_REF_SLUG\" == \"master\" ] && docker push $CI_REGISTRY_IMAGE/sync || true"
     - "[ \"$CI_COMMIT_REF_SLUG\" == \"master\" ] && docker push $CI_REGISTRY_IMAGE/api || true"
+    - "[ \"$CI_COMMIT_REF_SLUG\" == \"master\" ] && docker push $CI_REGISTRY_IMAGE/full || true"
 
 staging:
   stage: deploy

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -36,3 +36,16 @@ release :neoscan_api do
         neoscan_web: :permanent
       ]
 end
+
+release :neoscan_full do
+  set version: current_version(:neoscan)
+  set commands: [migrate: "rel/commands/migrate.sh", seed: "rel/commands/seed.sh"]
+  set applications: [
+        :runtime_tools,
+        :neoscan,
+        neoscan_sync: :permanent,
+        neoscan_cache: :permanent,
+        neoscan_node: :permanent,
+        neoscan_web: :permanent
+      ]
+end


### PR DESCRIPTION
Add a docker image to simplify deployment on non production environment (api and sync node are note separated because scaling of the API is not needed)