### PR TITLE
Feature/time in ms option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Contents
 <!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:0 orderedList:0 -->
-- [How to contribute](#how-to-contribute)
+- [How to Contribute](#how-to-contribute)
 - [Run Docker](#run-docker)
 - [Run Tests](#run-tests)
 - [Raise Main Net Phoenix](#raise-main-net-phoenix)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To run, first install Elixir and Phoenix at:
 
 ## Run Docker
 
-You can skip this section if you do not wish to run docker. 
+You can skip this section if you do not wish to run docker.
 
 Using docker you can start the project with:
 - `docker-compose up -d`
@@ -46,7 +46,7 @@ To run the tests:
 
 ### Raise Main Net Phoenix
 
-To start your The Application/Phoenix server:
+To start the Application/Phoenix server:
 
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
@@ -55,7 +55,7 @@ To start your The Application/Phoenix server:
 
 ### Raise Test Net Phoenix
 
-To start your The Application/Phoenix server:
+To start the Application/Phoenix server:
 
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
@@ -76,7 +76,7 @@ To tarball:
 
 To file:
 
-`pg_dump -U postgres -h localhost -W -F t neoscan_dev > neoscan_dev_testnet`
+`pg_dump -U postgres -h localhost -W neoscan_dev > neoscan_dev_testnet`
 
 Restore:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Neoscan
 
+[![Gitlab](https://gitlab.com/CityOfZion/neo-scan/badges/master/build.svg)](https://gitlab.com/CityOfZion/neo-scan/pipelines)
+[![Coveralls](https://img.shields.io/coveralls/CityOfZion/neo-scan.svg?branch=master)](https://coveralls.io/github/CityOfZion/neo-scan)
+
+Elixir + Phoenix Blockchain explorer for NEO
+
 # Contents
 <!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:0 orderedList:0 -->
 - [How to Contribute](#how-to-contribute)
@@ -11,11 +16,6 @@
 - [Learn More](#learn-more)
 
 <!-- /TOC -->
-
-[![Gitlab](https://gitlab.com/CityOfZion/neo-scan/badges/master/build.svg)](https://gitlab.com/CityOfZion/neo-scan/pipelines)
-[![Coveralls](https://img.shields.io/coveralls/CityOfZion/neo-scan.svg?branch=master)](https://coveralls.io/github/CityOfZion/neo-scan)
-
-Elixir + Phoenix Blockchain explorer for NEO
 
 # How to Contribute
 

--- a/apps/neoscan_node/config/config.exs
+++ b/apps/neoscan_node/config/config.exs
@@ -38,11 +38,11 @@ config :neoscan_node,
     "http://seed8.ngd.network:10332",
     "http://seed9.ngd.network:10332",
     "http://seed10.ngd.network:10332",
-    "https://m1.neo.neonexchange.org",
-    "https://m2.neo.neonexchange.org",
-    "https://m3.neo.neonexchange.org",
-    "https://m4.neo.neonexchange.org",
-    "https://m5.neo.neonexchange.org"
+    "https://m1.neo.nash.io",
+    "https://m2.neo.nash.io",
+    "https://m3.neo.nash.io",
+    "https://m4.neo.nash.io",
+    "https://m5.neo.nash.io"
   ]
 
 if Mix.env() == :test do

--- a/apps/neoscan_web/assets/js/app.js
+++ b/apps/neoscan_web/assets/js/app.js
@@ -24,7 +24,7 @@ import socket from './home_app'
 const moment = require("moment");
 
 const get_local_time = time => {
-    return (moment.unix(time).format('DD-MM-YYYY') + ' | ' + moment.unix(time).format('HH:mm:ss'))
+    return (moment.unix(time).format('DD-MM-YYYY') + ' | ' + moment.unix(time).format('HH:mm:ss:SSS A') + ' | ' + moment.unix(time).format('x') + ' (Unix ms)')
 }
 
 function isNumber(n) {


### PR DESCRIPTION
This PR adds rendering to Neoscan to support future subsecond block time. It also includes AM/PM indication, and unix time in ms as shown in the screenshot below. 

This change does not affect the relative formatting.

![image](https://user-images.githubusercontent.com/7162325/60917935-a2481c00-a257-11e9-8988-8ebe58d232a3.png)

I did this as an exercise to learn more about the system. I understand if you aren't concerned with this now. From what I understand only custom versions of neo-cli would be able to produce chains that would  be able to track this as Neo 2 is only using Unix time in seconds.

This addresses:

https://github.com/CityOfZion/neo-scan/issues/397

I'm open to suggestions and discussion around formatting as what I've performed here is just an example. Feedback appreciated. Thanks!